### PR TITLE
fix: sync image variable paths after vault renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+### 🐛 Fixed
+
+- **Image variable path tracking**: Automatically update configured image-variable paths when a vault image file or containing folder is moved or renamed, then republish affected variables and refresh matching built-in backgrounds.
+
+<details>
+<summary>中文说明（点击展开）</summary>
+
+### 🐛 修复
+
+- **图片变量路径跟踪**：在仓库内移动或重命名图片文件及其上层文件夹时，自动更新已配置的图片变量路径，并重新发布受影响变量、刷新匹配的内置背景。
+
+</details>
+
+---
+
 ## [0.3.3] - 2026-08-07
 ### 🚀 Added
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Obsidian regenerates resource URLs on vault reload, so raw paths are not stable 
 
 ![Image variable](assets/setting-image-var.webp)
 
-Pick an image in settings, assign a CSS variable name, and then use `var(--name)` directly in your CSS.
+Pick an image in settings, assign a CSS variable name, and then use `var(--name)` directly in your CSS. If you later move or rename that image or one of its containing folders inside the vault, the plugin automatically updates the stored path so your variable keeps pointing to the right file.
 
 Click the preview image on the left to quickly copy the variable reference:  
 ![Copy image variable](assets/setting-copy-image-var.webp)
@@ -151,7 +151,7 @@ Obsidian 每次重载仓库时都会重新生成资源 URL，因此原始路径�
 ![Image variable](assets/setting-image-var.webp)
 
 
-只需要在设置中选择图片文件，分配给它的 CSS 变量名——Viola！你就可以在 CSS 中直接使用 `var(--name)` 来引用它了。  
+只需要在设置中选择图片文件，分配给它的 CSS 变量名——Viola！你就可以在 CSS 中直接使用 `var(--name)` 来引用它了。如果后续在仓库内移动或重命名了该图片或它所在的上层文件夹，插件会自动更新保存的路径，变量引用始终有效。
 
 点击左侧的预览图片可以快速复制该图片变量：  
 ![alt text](assets/setting-copy-image-var.webp)

--- a/main.ts
+++ b/main.ts
@@ -4,6 +4,7 @@ import { ThemeContextService } from './src/services/ThemeContextService';
 import { NotePathContextService } from './src/services/NotePathContextService';
 import { ResourceVariableService } from './src/services/ResourceVariableService';
 import { BackgroundImageService } from './src/services/BackgroundImageService';
+import { ResourcePathSyncService } from './src/services/ResourcePathSyncService';
 import { SettingsTab } from './src/settings/SettingsTab';
 import { registerCommands } from './src/commands';
 
@@ -13,6 +14,8 @@ export default class StyleContextPlugin extends Plugin {
 	notePathCtx!: NotePathContextService;
 	resourceVarCtx!: ResourceVariableService;
 	backgroundImageCtx!: BackgroundImageService;
+	resourcePathSync!: ResourcePathSyncService;
+	settingsTab!: SettingsTab;
 
 	async onload(): Promise<void> {
 		await this.loadSettings();
@@ -27,13 +30,25 @@ export default class StyleContextPlugin extends Plugin {
 			() => this.settings,
 			this.app,
 		);
+		this.settingsTab = new SettingsTab(this.app, this);
+		this.resourcePathSync = new ResourcePathSyncService(
+			this,
+			() => this.settings,
+			async ({ backgroundAffected }) => {
+				await this.saveSettings();
+				this.resourceVarCtx.apply();
+				if (backgroundAffected) this.applyBackgroundImage();
+				this.settingsTab.refreshIfRendered();
+			},
+		);
 
-		this.addSettingTab(new SettingsTab(this.app, this));
+		this.addSettingTab(this.settingsTab);
 		registerCommands(this);
 		this.registerEvent(
 			this.app.workspace.on('window-open', () => this.applyAll()),
 		);
 
+		this.resourcePathSync.enable();
 		this.applyAll();
 	}
 
@@ -110,5 +125,6 @@ export default class StyleContextPlugin extends Plugin {
 		this.notePathCtx.disable();
 		this.resourceVarCtx.disable();
 		this.backgroundImageCtx.disable();
+		this.resourcePathSync.disable();
 	}
 }

--- a/src/services/ResourcePathSyncService.ts
+++ b/src/services/ResourcePathSyncService.ts
@@ -1,0 +1,69 @@
+import type { Plugin, TAbstractFile } from 'obsidian';
+import type { StyleContextSettings } from '../types';
+import { referencesImageVariable } from '../utils/background';
+import {
+	rewriteResourcePaths,
+	type ResourcePathRewriteResult,
+} from '../utils/resourcePaths';
+
+export interface ResourcePathSyncResult extends ResourcePathRewriteResult {
+	backgroundAffected: boolean;
+}
+
+type CommitResourcePathSync = (result: ResourcePathSyncResult) => Promise<void>;
+
+/** Keeps configured image variable paths current after Obsidian rename/move events. */
+export class ResourcePathSyncService {
+	private readonly plugin: Plugin;
+	private readonly getSettings: () => StyleContextSettings;
+	private readonly commit: CommitResourcePathSync;
+	private enabled = false;
+	private listenersRegistered = false;
+
+	constructor(
+		plugin: Plugin,
+		getSettings: () => StyleContextSettings,
+		commit: CommitResourcePathSync,
+	) {
+		this.plugin = plugin;
+		this.getSettings = getSettings;
+		this.commit = commit;
+	}
+
+	enable(): void {
+		this.enabled = true;
+		if (this.listenersRegistered) return;
+
+		this.listenersRegistered = true;
+		this.plugin.registerEvent(
+			this.plugin.app.vault.on('rename', (file, oldPath) => {
+				void this.handleRename(file, oldPath);
+			}),
+		);
+	}
+
+	disable(): void {
+		this.enabled = false;
+	}
+
+	async handleRename(
+		file: TAbstractFile,
+		oldPath: string,
+	): Promise<ResourcePathSyncResult | null> {
+		if (!this.enabled) return null;
+
+		const settings = this.getSettings();
+		const rewrite = rewriteResourcePaths(settings.resourceRules, oldPath, file.path);
+		if (rewrite === null) return null;
+
+		const result: ResourcePathSyncResult = {
+			...rewrite,
+			backgroundAffected: referencesImageVariable(
+				settings.backgroundImage.imageValue,
+				rewrite.updatedVariableNames,
+			),
+		};
+		await this.commit(result);
+		return result;
+	}
+}

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -116,6 +116,7 @@ export class SettingsTab extends PluginSettingTab {
 	private rulePreviewTiles = new Map<string, HTMLElement>();
 	private backgroundImageValuePreview: HTMLElement | null = null;
 	private backgroundImagePreview: HTMLElement | null = null;
+	private isRendered = false;
 
 	constructor(app: App, plugin: StyleContextPlugin) {
 		super(app, plugin);
@@ -127,6 +128,7 @@ export class SettingsTab extends PluginSettingTab {
 	// ------------------------------------------------------------------
 
 	getSettingDefinitions(): SettingDefinitionItem<ControlKey>[] {
+		this.isRendered = true;
 		// A detached Settings window has its own Document. Republish before
 		// rendering so image variables and live previews are immediately
 		// available there without forcing the user to reselect an image.
@@ -174,8 +176,13 @@ export class SettingsTab extends PluginSettingTab {
 	}
 
 	hide(): void {
+		this.isRendered = false;
 		this.stopDiagnosticsRefresh();
 		super.hide();
+	}
+
+	refreshIfRendered(): void {
+		if (this.isRendered) this.update();
 	}
 
 	// ------------------------------------------------------------------

--- a/src/utils/background.ts
+++ b/src/utils/background.ts
@@ -2,6 +2,7 @@ import type { ResourceRule } from '../types';
 import { isValidCssVarName } from './validation';
 
 const FALLBACK_IMAGE_FUNCTION_RE = /^(?:none|(?:-webkit-)?(?:url|var|image|image-set|cross-fade|element|paint|(?:repeating-)?(?:linear|radial|conic)-gradient)\s*\()/i;
+const BARE_VAR_RE = /^var\(\s*(--[-_a-zA-Z][-_a-zA-Z0-9]*)\s*\)$/;
 
 /** Trims a complete CSS background-image value supplied by the user. */
 export function normalizeBackgroundImageValue(value: unknown): string {
@@ -30,6 +31,15 @@ export function isValidBackgroundImageValue(value: unknown): boolean {
 	// JSDOM and older webviews may not expose CSS.supports. Keep the fallback
 	// conservative; the browser still parses the value through setProperty().
 	return !/[;{}]/.test(normalized) && FALLBACK_IMAGE_FUNCTION_RE.test(normalized);
+}
+
+/** Returns true only for a bare `var(--name)` that references an updated image variable. */
+export function referencesImageVariable(
+	value: unknown,
+	variableNames: readonly string[],
+): boolean {
+	const match = BARE_VAR_RE.exec(normalizeBackgroundImageValue(value));
+	return match?.[1] !== undefined && variableNames.includes(match[1]);
 }
 
 /**

--- a/src/utils/resourcePaths.ts
+++ b/src/utils/resourcePaths.ts
@@ -1,0 +1,67 @@
+import { normalizePath } from 'obsidian';
+import type { ResourceRule } from '../types';
+
+export interface ResourcePathUpdate {
+	ruleId: string;
+	variableName: string;
+	previousPath: string;
+	nextPath: string;
+}
+
+export interface ResourcePathRewriteResult {
+	updates: ResourcePathUpdate[];
+	updatedVariableNames: string[];
+}
+
+/**
+ * Rewrites one stored resource path for an Obsidian rename/move event.
+ * Exact matches and slash-bound descendants are updated; sibling prefixes are not.
+ */
+export function remapResourcePath(
+	storedPath: string,
+	oldPath: string,
+	newPath: string,
+): string | null {
+	const stored = normalizePath(storedPath);
+	const oldNormalized = normalizePath(oldPath);
+	const newNormalized = normalizePath(newPath);
+	if (stored === '' || oldNormalized === '' || newNormalized === '') return null;
+
+	const oldPrefix = `${oldNormalized}/`;
+	const nextPath = stored === oldNormalized
+		? newNormalized
+		: stored.startsWith(oldPrefix)
+			? `${newNormalized}/${stored.slice(oldPrefix.length)}`
+			: null;
+
+	return nextPath !== null && nextPath !== stored ? nextPath : null;
+}
+
+/** Mutates matching resource rules in place so existing Settings UI references stay current. */
+export function rewriteResourcePaths(
+	rules: readonly ResourceRule[],
+	oldPath: string,
+	newPath: string,
+): ResourcePathRewriteResult | null {
+	const updates: ResourcePathUpdate[] = [];
+	const updatedVariableNames = new Set<string>();
+
+	for (const rule of rules) {
+		const nextPath = remapResourcePath(rule.filePath, oldPath, newPath);
+		if (nextPath === null) continue;
+
+		const previousPath = normalizePath(rule.filePath);
+		rule.filePath = nextPath;
+		updates.push({
+			ruleId: rule.id,
+			variableName: rule.variableName,
+			previousPath,
+			nextPath,
+		});
+		updatedVariableNames.add(rule.variableName);
+	}
+
+	return updates.length > 0
+		? { updates, updatedVariableNames: [...updatedVariableNames] }
+		: null;
+}

--- a/tests/resourcePaths.test.ts
+++ b/tests/resourcePaths.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import type { ResourceRule } from '../src/types';
+import {
+	remapResourcePath,
+	rewriteResourcePaths,
+} from '../src/utils/resourcePaths';
+
+function rule(
+	id: string,
+	filePath: string,
+	variableName = `--${id}`,
+	enabled = true,
+): ResourceRule {
+	return { id, filePath, variableName, enabled };
+}
+
+describe('remapResourcePath', () => {
+	it('rewrites exact file renames and cross-folder moves', () => {
+		// Given: a stored image path matching the vault rename source.
+		// When: Obsidian reports the file at its new path.
+		// Then: the stored path follows the moved file.
+		expect(
+			remapResourcePath('assets/Hero.PNG', 'assets/Hero.PNG', 'media/Banner.PNG'),
+		).toBe('media/Banner.PNG');
+		expect(
+			remapResourcePath('inbox/Hero.PNG', 'inbox/Hero.PNG', 'archive/Hero.PNG'),
+		).toBe('archive/Hero.PNG');
+	});
+
+	it('rewrites folder descendants and the folder path itself', () => {
+		// Given: resource rules stored below a folder path.
+		// When: the folder is renamed.
+		// Then: exact and descendant paths move under the new folder.
+		expect(remapResourcePath('assets/img', 'assets/img', 'media/pics')).toBe(
+			'media/pics',
+		);
+		expect(
+			remapResourcePath('assets/img/deep/Icon.png', 'assets/img', 'media/pics'),
+		).toBe('media/pics/deep/Icon.png');
+	});
+
+	it('does not rewrite sibling prefixes or unrelated paths', () => {
+		// Given: paths that only look similar to the renamed folder.
+		// When: the old path is a prefix without a slash boundary.
+		// Then: no rewrite happens.
+		expect(remapResourcePath('assets/imgx/Icon.png', 'assets/img', 'media/pics')).toBeNull();
+		expect(remapResourcePath('other/Icon.png', 'assets/img', 'media/pics')).toBeNull();
+	});
+
+	it('ignores empty inputs and idempotent no-ops', () => {
+		// Given: missing or already-updated path inputs.
+		// When: remapping cannot produce a meaningful change.
+		// Then: null signals no update.
+		expect(remapResourcePath('', 'assets/Hero.PNG', 'media/Banner.PNG')).toBeNull();
+		expect(remapResourcePath('assets/Hero.PNG', '', 'media/Banner.PNG')).toBeNull();
+		expect(remapResourcePath('assets/Hero.PNG', 'assets/Hero.PNG', '')).toBeNull();
+		expect(remapResourcePath('media/Banner.PNG', 'media/Banner.PNG', 'media/Banner.PNG')).toBeNull();
+	});
+
+	it('normalizes stored, old, and new paths before matching', () => {
+		// Given: paths with platform separators and redundant slashes.
+		// When: the same logical path is renamed.
+		// Then: the persisted result uses normalized vault paths.
+		expect(
+			remapResourcePath('assets\\img//Hero.PNG', '/assets/img', 'media\\pics/'),
+		).toBe('media/pics/Hero.PNG');
+	});
+});
+
+describe('rewriteResourcePaths', () => {
+	it('mutates enabled and disabled matching rules and reports updated variables', () => {
+		// Given: active and disabled rules below the renamed folder.
+		const rules = [
+			rule('hero', 'assets/img/Hero.PNG', '--hero-image'),
+			rule('disabled', 'assets/img/Old.PNG', '--disabled-image', false),
+			rule('sibling', 'assets/imgx/Other.PNG', '--other-image'),
+		];
+
+		// When: the containing folder is renamed.
+		const result = rewriteResourcePaths(rules, 'assets/img', 'media/pics');
+
+		// Then: only exact descendants update, including disabled rules.
+		expect(rules.map((item) => item.filePath)).toEqual([
+			'media/pics/Hero.PNG',
+			'media/pics/Old.PNG',
+			'assets/imgx/Other.PNG',
+		]);
+		expect(result).toEqual({
+			updates: [
+				{
+					ruleId: 'hero',
+					variableName: '--hero-image',
+					previousPath: 'assets/img/Hero.PNG',
+					nextPath: 'media/pics/Hero.PNG',
+				},
+				{
+					ruleId: 'disabled',
+					variableName: '--disabled-image',
+					previousPath: 'assets/img/Old.PNG',
+					nextPath: 'media/pics/Old.PNG',
+				},
+			],
+			updatedVariableNames: ['--hero-image', '--disabled-image'],
+		});
+	});
+
+	it('returns null and leaves rules untouched when nothing matches', () => {
+		// Given: a resource rule outside the renamed path.
+		const rules = [rule('hero', 'assets/Hero.PNG', '--hero-image')];
+
+		// When: a different path is renamed.
+		const result = rewriteResourcePaths(rules, 'notes/Journal.md', 'notes/Diary.md');
+
+		// Then: settings are untouched and no update is reported.
+		expect(result).toBeNull();
+		expect(rules[0]?.filePath).toBe('assets/Hero.PNG');
+	});
+
+	it('converges when folder and child rename events are delivered in either order', () => {
+		// Given: two equivalent event orders for a moved folder and a moved child.
+		const folderFirst = [rule('hero', 'assets/img/Hero.PNG', '--hero-image')];
+		const childFirst = [rule('hero', 'assets/img/Hero.PNG', '--hero-image')];
+
+		// When: the events are applied in opposite order.
+		rewriteResourcePaths(folderFirst, 'assets/img', 'media/pics');
+		rewriteResourcePaths(folderFirst, 'assets/img/Hero.PNG', 'media/pics/Hero.PNG');
+		rewriteResourcePaths(childFirst, 'assets/img/Hero.PNG', 'media/pics/Hero.PNG');
+		rewriteResourcePaths(childFirst, 'assets/img', 'media/pics');
+
+		// Then: both sequences reach the same normalized stored path.
+		expect(folderFirst[0]?.filePath).toBe('media/pics/Hero.PNG');
+		expect(childFirst[0]?.filePath).toBe('media/pics/Hero.PNG');
+	});
+});

--- a/tests/services.test.ts
+++ b/tests/services.test.ts
@@ -5,6 +5,10 @@ import { ThemeContextService } from '../src/services/ThemeContextService';
 import { ResourceVariableService } from '../src/services/ResourceVariableService';
 import { NotePathContextService } from '../src/services/NotePathContextService';
 import { BackgroundImageService } from '../src/services/BackgroundImageService';
+import {
+	ResourcePathSyncService,
+	type ResourcePathSyncResult,
+} from '../src/services/ResourcePathSyncService';
 
 type ListenerMap = Map<string, () => void>;
 
@@ -13,6 +17,36 @@ function createEventSource(listeners: ListenerMap) {
 		listeners.set(event, callback);
 		return { event, callback };
 	});
+}
+
+/** A vault renamed item as reported by the `rename` event. */
+type RenamedItem = TFile | { path: string };
+
+type RenameListener = (item: RenamedItem, oldPath: string) => void;
+
+type RenameListenerMap = Map<string, RenameListener[]>;
+
+/**
+ * Like `createEventSource`, but keeps every registration and forwards the
+ * `(item, oldPath)` arguments the rename event carries.
+ */
+function createRenameEventSource(listeners: RenameListenerMap) {
+	return vi.fn((event: string, callback: RenameListener) => {
+		const existing = listeners.get(event) ?? [];
+		existing.push(callback);
+		listeners.set(event, existing);
+		return { event, callback };
+	});
+}
+
+function emitRename(
+	listeners: RenameListenerMap,
+	item: RenamedItem,
+	oldPath: string,
+): void {
+	for (const listener of listeners.get('rename') ?? []) {
+		listener(item, oldPath);
+	}
 }
 
 function settings(
@@ -488,6 +522,318 @@ describe('ResourceVariableService', () => {
 		expect(
 			settingsDocument.documentElement.style.getPropertyValue('--hero-image'),
 		).toBe('url("app://vault/assets/Hero.PNG")');
+	});
+});
+
+interface SyncHarnessOptions {
+	rules: StyleContextSettings['resourceRules'];
+	overrides?: Partial<StyleContextSettings>;
+}
+
+function createSyncHarness(options: SyncHarnessOptions) {
+	const listeners: RenameListenerMap = new Map();
+	const vaultOn = createRenameEventSource(listeners);
+	const registerEvent = vi.fn();
+	const plugin = { app: { vault: { on: vaultOn } }, registerEvent };
+	const currentSettings = settings({
+		...options.overrides,
+		resourceRules: options.rules,
+	});
+	const commits: ResourcePathSyncResult[] = [];
+	const commit = vi.fn(async (result: ResourcePathSyncResult) => {
+		commits.push(result);
+	});
+	const service = new ResourcePathSyncService(
+		plugin as never,
+		() => currentSettings,
+		commit,
+	);
+
+	return {
+		commit,
+		commits,
+		currentSettings,
+		listeners,
+		registerEvent,
+		service,
+		vaultOn,
+	};
+}
+
+/** Drains the microtask queue so queued saves have a chance to start. */
+function flushMicrotasks(): Promise<void> {
+	return new Promise<void>((resolve) => {
+		setTimeout(resolve, 0);
+	});
+}
+
+describe('ResourcePathSyncService', () => {
+	it('updates a matching rule and commits the affected variables', async () => {
+		const harness = createSyncHarness({
+			rules: [
+				{
+					id: 'hero',
+					filePath: 'assets/Hero.PNG',
+					variableName: '--hero-image',
+					enabled: true,
+				},
+			],
+		});
+		const rule = harness.currentSettings.resourceRules[0];
+		harness.service.enable();
+
+		emitRename(
+			harness.listeners,
+			new TFile('media/Banner.PNG'),
+			'assets/Hero.PNG',
+		);
+		await flushMicrotasks();
+
+		expect(harness.currentSettings.resourceRules[0]).toBe(rule);
+		expect(rule?.filePath).toBe('media/Banner.PNG');
+		expect(harness.commit).toHaveBeenCalledTimes(1);
+		expect(harness.commits[0]).toEqual({
+			updates: [
+				{
+					ruleId: 'hero',
+					variableName: '--hero-image',
+					previousPath: 'assets/Hero.PNG',
+					nextPath: 'media/Banner.PNG',
+				},
+			],
+			updatedVariableNames: ['--hero-image'],
+			backgroundAffected: false,
+		});
+	});
+
+	it('rewrites folder descendants, disabled rules, and leaves outsiders untouched', async () => {
+		const harness = createSyncHarness({
+			rules: [
+				{
+					id: 'exact',
+					filePath: 'assets/img',
+					variableName: '--img-dir',
+					enabled: true,
+				},
+				{
+					id: 'direct',
+					filePath: 'assets/img/Hero.PNG',
+					variableName: '--hero-image',
+					enabled: true,
+				},
+				{
+					id: 'nested',
+					filePath: 'assets/img/deep/Icon.png',
+					variableName: '--icon-image',
+					enabled: false,
+				},
+				{
+					id: 'sibling',
+					filePath: 'assets/imgx/Other.png',
+					variableName: '--other-image',
+					enabled: true,
+				},
+			],
+		});
+		harness.service.enable();
+
+		emitRename(harness.listeners, { path: 'media/pics' }, 'assets/img');
+		await flushMicrotasks();
+
+		expect(
+			harness.currentSettings.resourceRules.map((rule) => rule.filePath),
+		).toEqual([
+			'media/pics',
+			'media/pics/Hero.PNG',
+			'media/pics/deep/Icon.png',
+			'assets/imgx/Other.png',
+		]);
+		expect(harness.commit).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not commit when no resource path changes', async () => {
+		const harness = createSyncHarness({
+			rules: [
+				{
+					id: 'hero',
+					filePath: 'assets/Hero.PNG',
+					variableName: '--hero-image',
+					enabled: true,
+				},
+			],
+		});
+		harness.service.enable();
+
+		emitRename(harness.listeners, new TFile('notes/Diary.md'), 'notes/Journal.md');
+		await flushMicrotasks();
+
+		expect(harness.currentSettings.resourceRules[0]?.filePath).toBe(
+			'assets/Hero.PNG',
+		);
+		expect(harness.commit).not.toHaveBeenCalled();
+	});
+
+	it('marks background affected only for a bare matching image variable', async () => {
+		const harness = createSyncHarness({
+			rules: [
+				{
+					id: 'hero',
+					filePath: 'assets/Hero.PNG',
+					variableName: '--hero-image',
+					enabled: true,
+				},
+			],
+			overrides: {
+				backgroundImage: {
+					...DEFAULT_SETTINGS.backgroundImage,
+					enabled: true,
+					imageValue: ' var( --hero-image ) ',
+				},
+			},
+		});
+		harness.service.enable();
+
+		emitRename(
+			harness.listeners,
+			new TFile('media/Banner.PNG'),
+			'assets/Hero.PNG',
+		);
+		await flushMicrotasks();
+
+		expect(harness.commits[0]?.backgroundAffected).toBe(true);
+	});
+
+	it('leaves background unaffected for wrapped or unrelated image variables', async () => {
+		const wrapped = createSyncHarness({
+			rules: [
+				{
+					id: 'hero',
+					filePath: 'assets/Hero.PNG',
+					variableName: '--hero-image',
+					enabled: true,
+				},
+			],
+			overrides: {
+				backgroundImage: {
+					...DEFAULT_SETTINGS.backgroundImage,
+					enabled: true,
+					imageValue: 'url(var(--hero-image))',
+				},
+			},
+		});
+		const unrelated = createSyncHarness({
+			rules: [
+				{
+					id: 'hero',
+					filePath: 'assets/Hero.PNG',
+					variableName: '--hero-image',
+					enabled: true,
+				},
+			],
+			overrides: {
+				backgroundImage: {
+					...DEFAULT_SETTINGS.backgroundImage,
+					enabled: true,
+					imageValue: 'var(--other-image)',
+				},
+			},
+		});
+
+		wrapped.service.enable();
+		unrelated.service.enable();
+		emitRename(wrapped.listeners, new TFile('media/Banner.PNG'), 'assets/Hero.PNG');
+		emitRename(unrelated.listeners, new TFile('media/Banner.PNG'), 'assets/Hero.PNG');
+		await flushMicrotasks();
+
+		expect(wrapped.commits[0]?.backgroundAffected).toBe(false);
+		expect(unrelated.commits[0]?.backgroundAffected).toBe(false);
+	});
+
+	it('registers once through enable-disable-enable', () => {
+		const harness = createSyncHarness({ rules: [] });
+
+		harness.service.enable();
+		harness.service.disable();
+		harness.service.enable();
+
+		expect(harness.vaultOn).toHaveBeenCalledTimes(1);
+		expect(harness.vaultOn.mock.calls[0]?.[0]).toBe('rename');
+		expect(harness.registerEvent).toHaveBeenCalledTimes(1);
+	});
+
+	it('stays inert after disable', async () => {
+		const harness = createSyncHarness({
+			rules: [
+				{
+					id: 'hero',
+					filePath: 'assets/Hero.PNG',
+					variableName: '--hero-image',
+					enabled: true,
+				},
+			],
+		});
+		harness.service.enable();
+		harness.service.disable();
+
+		emitRename(
+			harness.listeners,
+			new TFile('media/Banner.PNG'),
+			'assets/Hero.PNG',
+		);
+		await flushMicrotasks();
+
+		expect(harness.currentSettings.resourceRules[0]?.filePath).toBe(
+			'assets/Hero.PNG',
+		);
+		expect(harness.commit).not.toHaveBeenCalled();
+	});
+
+	it('converges when duplicate folder and child events arrive in either order', async () => {
+		const folderFirst = createSyncHarness({
+			rules: [
+				{
+					id: 'hero',
+					filePath: 'assets/img/Hero.PNG',
+					variableName: '--hero-image',
+					enabled: true,
+				},
+			],
+		});
+		const childFirst = createSyncHarness({
+			rules: [
+				{
+					id: 'hero',
+					filePath: 'assets/img/Hero.PNG',
+					variableName: '--hero-image',
+					enabled: true,
+				},
+			],
+		});
+		folderFirst.service.enable();
+		childFirst.service.enable();
+
+		emitRename(folderFirst.listeners, { path: 'media/pics' }, 'assets/img');
+		emitRename(
+			folderFirst.listeners,
+			new TFile('media/pics/Hero.PNG'),
+			'assets/img/Hero.PNG',
+		);
+		emitRename(
+			childFirst.listeners,
+			new TFile('media/pics/Hero.PNG'),
+			'assets/img/Hero.PNG',
+		);
+		emitRename(childFirst.listeners, { path: 'media/pics' }, 'assets/img');
+		await flushMicrotasks();
+
+		expect(folderFirst.currentSettings.resourceRules[0]?.filePath).toBe(
+			'media/pics/Hero.PNG',
+		);
+		expect(childFirst.currentSettings.resourceRules[0]?.filePath).toBe(
+			'media/pics/Hero.PNG',
+		);
+		expect(folderFirst.commit).toHaveBeenCalledTimes(1);
+		expect(childFirst.commit).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -5,6 +5,7 @@ import {
 	isValidBackgroundImageValue,
 	normalizeBackgroundImageValue,
 	pickRandomBackgroundImageValue,
+	referencesImageVariable,
 } from '../src/utils/background';
 import { themeSlug } from '../src/utils/slug';
 import {
@@ -102,5 +103,19 @@ describe('background image values', () => {
 		expect(isBareBackgroundImageVariable(' --hero-image ')).toBe(true);
 		expect(isBareBackgroundImageVariable('var(--hero-image)')).toBe(false);
 		expect(isBareBackgroundImageVariable('hero-image')).toBe(false);
+	});
+
+	it('detects only bare matching background var() values', () => {
+		const variables = ['--hero-image', '--cover-image'];
+
+		expect(referencesImageVariable(' var( --hero-image ) ', variables)).toBe(true);
+		expect(referencesImageVariable('var(--cover-image)', variables)).toBe(true);
+		expect(referencesImageVariable('url(var(--hero-image))', variables)).toBe(false);
+		expect(referencesImageVariable('var(--hero-image), var(--cover-image)', variables)).toBe(false);
+		expect(referencesImageVariable('linear-gradient(red, blue)', variables)).toBe(false);
+		expect(referencesImageVariable('none', variables)).toBe(false);
+		expect(referencesImageVariable('var(--other-image)', variables)).toBe(false);
+		expect(referencesImageVariable('--hero-image', variables)).toBe(false);
+		expect(referencesImageVariable(null, variables)).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary
- Add vault rename/move path remapping for configured image variables.
- Rewrite exact file paths and descendants when folders are renamed.
- Persist updated settings, republish resource variables, and refresh matching background references.
- Keep the listener active even when resource variable publishing is disabled.

## Verification
- npm run check passed.
- 5 test files passed, 51 tests passed.
- TypeScript diagnostics passed for all changed TypeScript files.
- npm run build passed.
- npm run build:local was not run because VAULT_PATH is not configured in this environment.