### PR TITLE
feat: composer theme compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+### 🐛 Fixed
+
+- **Gradient theme canvases**: Honor `--background-gradient` (e.g. Composer) instead of flattening the canvas to `--background-primary` — the body repaint and the image layer's blend base keep the theme's gradient, in the settings preview too. All theme canvas tokens resolve through the single `--sc-style-context-theme-canvas` fallback chain in styles.css, so new theme tokens are a one-line append.
+- **Transparency reset priority**: Repeat the marker class in every transparency reset so same-specificity theme rules (loaded after plugin CSS, such as Composer's workspace gradient) can no longer cover the background image.
+
+<details>
+<summary>中文说明（点击展开）</summary>
+
+### 🐛 修复
+
+- **渐变主题画布**：兼容通过 `--background-gradient` 表达画布的主题（如 Composer），body 重绘与图片图层的混合基底保留主题渐变，不再压平为 `--background-primary` 纯色，设置页预览同步该表现。所有主题画布 token 统一收口到 styles.css 的 `--sc-style-context-theme-canvas` 兜底链，新增主题 token 只需追加一行。
+- **透明规则优先级**：所有透明化规则重复标记 class，避免同特异性主题规则（在插件 CSS 之后加载，如 Composer 的 workspace 渐变）盖住背景图。
+
+</details>
+
+---
+
 ## [0.3.5] - 2026-08-07
 ### 🐛 Fixed
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ VAULT_PATH=C:/path/to/your/ObsidianVault
 
 you can run `npm run build:local` to build and auto-copy into your vault.
 
+### Theme compatibility
+
+The background image repaints the canvas, so themes deviating from Obsidian's default canvas model are absorbed by a dedicated compatibility layer at the top of `styles.css`. It has exactly two extension points — supporting a new theme touches these and nothing else:
+
+- **Canvas token chain** (`--sc-style-context-theme-canvas`): how a theme *expresses* its canvas. Solid `--background-primary` themes need no entry; a theme with its own token (e.g. Composer's `--background-gradient`) appends it to the fallback chain.
+- **Surface resets**: which elements *cover* the canvas. The selector lists reset Obsidian's standard containers and repeat the marker class so equal-specificity theme rules (theme.css loads after plugin CSS) cannot win; a theme painting extra opaque surfaces adds its selectors to the matching list.
+
+Theme behavior beyond CSS reach — JS-injected styles or `!important` rules — is out of scope.
+
 ## Release
 
 After writing complete notes under `## [Unreleased]`, run `npm run release -- <version>`. The command requires a clean, synchronized default branch; it synchronizes all version metadata, promotes the changelog entry, runs checks, commits, creates and atomically pushes the tag, then waits for GitHub Actions to verify the published Release and its three plugin assets. Use `npm run release:dry-run -- <version>` to validate without changing anything.
@@ -224,6 +233,15 @@ VAULT_PATH=C:/path/to/your/ObsidianVault
 ```
 
 那么你就可以直接使用 `npm run build:local` 来构建并自动拷贝到你的仓库内 `;)`
+
+### 主题兼容
+
+背景图会重绘画布，因此偏离 Obsidian 默认画布模型的主题由 `styles.css` 顶部的兼容层统一吸收。它有且只有两个扩展点——兼容新主题只动这两处：
+
+- **画布 token 链**（`--sc-style-context-theme-canvas`）：主题如何*表达*画布。使用纯色 `--background-primary` 的主题无需登记；使用自有 token 的主题（如 Composer 的 `--background-gradient`）把它追加进兜底链。
+- **表面重置**：哪些元素*覆盖*画布。选择器列表重置 Obsidian 标准容器并重复标记 class，使同特异性的主题规则（theme.css 在插件 CSS 之后加载）无法获胜；若某主题在额外表面上绘制不透明背景，把选择器加进对应列表。
+
+超出 CSS 能力的主题行为——JS 注入样式或 `!important` 规则——不在处理范围内。
 
 ## 发布
 

--- a/src/services/BackgroundImageService.ts
+++ b/src/services/BackgroundImageService.ts
@@ -180,6 +180,15 @@ export function resolveBackgroundImageStyle(
  * canvas color, so a faded layer cross-fades toward the theme color — at zero
  * opacity the canvas falls back to the theme's canvas color instead of the
  * bare app backdrop.
+ *
+ * Theme compatibility lives in a dedicated styles.css layer with exactly
+ * two extension points: the --sc-style-context-theme-canvas token chain
+ * (how a theme expresses its canvas — e.g. Composer's --background-gradient
+ * instead of a solid --background-primary) and the surface-reset selector
+ * lists (which elements cover the canvas). The chain is painted on the
+ * repainted body and layered beneath the image, so blend and cross-fade
+ * stay anchored to the theme's real canvas; supporting a new theme only
+ * extends those two points.
  */
 export class BackgroundImageService {
 	private getSettings: () => StyleContextSettings;

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,32 @@
 /* Style Context - built-in background image */
 
-body.sc-style-context-background-image {
+/* ------------------------------------------------------------------
+   Theme compatibility layer
+   ------------------------------------------------------------------
+   The background image repaints the canvas, so themes that deviate from
+   Obsidian's default canvas model are absorbed here. Compatibility has
+   exactly two extension points — supporting a new theme touches these
+   and nothing else:
+
+   1. Canvas token chain (below): how a theme expresses its canvas.
+      Solid --background-primary themes need no entry; a theme with its
+      own token (Composer: --background-gradient) appends to the chain.
+   2. Surface resets (further down): which elements cover the canvas —
+      the canvas container list, plus the opt-out ribbon / titlebar /
+      status-bar / mobile-toolbar lists. A theme painting extra opaque
+      surfaces adds its selectors to the matching list.
+
+   Every reset repeats the marker class: theme.css loads after plugin CSS
+   and would otherwise win equal-specificity ties (!important is banned by
+   the stylelint config). Theme behavior beyond CSS reach — JS-injected
+   styles, !important rules — is out of scope. */
+body {
+	--sc-style-context-theme-canvas: var(--background-gradient, none);
+}
+
+body.sc-style-context-background-image.sc-style-context-background-image {
 	background-color: var(--background-primary);
-	background-image: none;
+	background-image: var(--sc-style-context-theme-canvas);
 }
 
 body.sc-style-context-background-image::before {
@@ -11,9 +35,11 @@ body.sc-style-context-background-image::before {
 	inset: var(--sc-style-context-background-image-inset);
 	pointer-events: none;
 	z-index: -1;
-	background-image: var(--sc-style-context-background-image-value);
+	/* The theme canvas rides below the image as the blend base; its blend mode
+	   stays `normal` so the configured mode only affects the image itself. */
+	background-image: var(--sc-style-context-background-image-value), var(--sc-style-context-theme-canvas);
 	background-color: var(--background-primary);
-	background-blend-mode: var(--sc-style-context-background-image-blend-mode);
+	background-blend-mode: var(--sc-style-context-background-image-blend-mode), normal;
 	background-size: var(--sc-style-context-background-image-size);
 	background-position: var(--sc-style-context-background-image-position);
 	background-repeat: var(--sc-style-context-background-image-repeat);
@@ -22,38 +48,39 @@ body.sc-style-context-background-image::before {
 	filter: var(--sc-style-context-background-image-filter);
 }
 
-/* Let the fixed layer flow through Obsidian's standard canvas containers. */
-body.sc-style-context-background-image .app-container,
-body.sc-style-context-background-image.i-border-layout:not(.is-mobile) .app-container,
-body.sc-style-context-background-image .workspace,
-body.sc-style-context-background-image.theme-dark .workspace,
-body.sc-style-context-background-image .workspace-split,
-body.sc-style-context-background-image.theme-dark .workspace-split.mod-root,
-body.sc-style-context-background-image.is-mobile .workspace > .mod-root,
-body.sc-style-context-background-image .workspace-tab-container,
-body.sc-style-context-background-image .workspace-leaf,
-body.sc-style-context-background-image .workspace-tabs .workspace-leaf,
-body.sc-style-context-background-image.theme-dark .workspace-tabs .workspace-leaf,
-body.sc-style-context-background-image .mod-root .workspace-tabs .workspace-leaf,
-body.sc-style-context-background-image .workspace-fake-target-overlay:not(.is-in-sidebar) .workspace-tabs .workspace-leaf,
-body.sc-style-context-background-image .workspace-leaf-content,
-body.sc-style-context-background-image .view-content,
-body.sc-style-context-background-image .workspace-split.mod-root .view-content,
-body.sc-style-context-background-image .view-header,
-body.sc-style-context-background-image.is-focused .workspace-leaf.mod-active .view-header,
-body.sc-style-context-background-image .workspace-tab-header-container,
-body.sc-style-context-background-image .workspace-tabs,
-body.sc-style-context-background-image .sidebar-toggle-button,
-body.sc-style-context-background-image .nav-files-container,
-body.sc-style-context-background-image:not(.is-mobile) .workspace-split.mod-left-split .workspace-sidedock-vault-profile {
+/* Surface resets — let the fixed layer flow through Obsidian's standard
+   canvas containers; theme-specific surfaces join this list. */
+body.sc-style-context-background-image.sc-style-context-background-image .app-container,
+body.sc-style-context-background-image.sc-style-context-background-image.i-border-layout:not(.is-mobile) .app-container,
+body.sc-style-context-background-image.sc-style-context-background-image .workspace,
+body.sc-style-context-background-image.sc-style-context-background-image.theme-dark .workspace,
+body.sc-style-context-background-image.sc-style-context-background-image .workspace-split,
+body.sc-style-context-background-image.sc-style-context-background-image.theme-dark .workspace-split.mod-root,
+body.sc-style-context-background-image.sc-style-context-background-image.is-mobile .workspace > .mod-root,
+body.sc-style-context-background-image.sc-style-context-background-image .workspace-tab-container,
+body.sc-style-context-background-image.sc-style-context-background-image .workspace-leaf,
+body.sc-style-context-background-image.sc-style-context-background-image .workspace-tabs .workspace-leaf,
+body.sc-style-context-background-image.sc-style-context-background-image.theme-dark .workspace-tabs .workspace-leaf,
+body.sc-style-context-background-image.sc-style-context-background-image .mod-root .workspace-tabs .workspace-leaf,
+body.sc-style-context-background-image.sc-style-context-background-image .workspace-fake-target-overlay:not(.is-in-sidebar) .workspace-tabs .workspace-leaf,
+body.sc-style-context-background-image.sc-style-context-background-image .workspace-leaf-content,
+body.sc-style-context-background-image.sc-style-context-background-image .view-content,
+body.sc-style-context-background-image.sc-style-context-background-image .workspace-split.mod-root .view-content,
+body.sc-style-context-background-image.sc-style-context-background-image .view-header,
+body.sc-style-context-background-image.sc-style-context-background-image.is-focused .workspace-leaf.mod-active .view-header,
+body.sc-style-context-background-image.sc-style-context-background-image .workspace-tab-header-container,
+body.sc-style-context-background-image.sc-style-context-background-image .workspace-tabs,
+body.sc-style-context-background-image.sc-style-context-background-image .sidebar-toggle-button,
+body.sc-style-context-background-image.sc-style-context-background-image .nav-files-container,
+body.sc-style-context-background-image.sc-style-context-background-image:not(.is-mobile) .workspace-split.mod-left-split .workspace-sidedock-vault-profile {
 	background-color: transparent;
 	background-image: none;
 }
 
 /* Style Context - ribbon transparency (opt-out) */
 
-body.sc-style-context-background-image.sc-style-context-ribbon-transparent .workspace-ribbon,
-body.sc-style-context-background-image.sc-style-context-ribbon-transparent .workspace-ribbon.mod-left::before {
+body.sc-style-context-background-image.sc-style-context-background-image.sc-style-context-ribbon-transparent .workspace-ribbon,
+body.sc-style-context-background-image.sc-style-context-background-image.sc-style-context-ribbon-transparent .workspace-ribbon.mod-left::before {
 	background-color: transparent;
 	background-image: none;
 }
@@ -62,9 +89,9 @@ body.sc-style-context-background-image.sc-style-context-ribbon-transparent .work
    `.sidebar-toggle-button` stays in the unconditional list above because it
    also renders inside mobile view headers, not just the title bar. */
 
-body.sc-style-context-background-image.sc-style-context-titlebar-transparent .titlebar,
-body.sc-style-context-background-image.sc-style-context-titlebar-transparent .titlebar-inner,
-body.sc-style-context-background-image.sc-style-context-titlebar-transparent .titlebar-button-container {
+body.sc-style-context-background-image.sc-style-context-background-image.sc-style-context-titlebar-transparent .titlebar,
+body.sc-style-context-background-image.sc-style-context-background-image.sc-style-context-titlebar-transparent .titlebar-inner,
+body.sc-style-context-background-image.sc-style-context-background-image.sc-style-context-titlebar-transparent .titlebar-button-container {
 	background-color: transparent;
 	background-image: none;
 }
@@ -75,19 +102,19 @@ body.sc-style-context-background-image.sc-style-context-titlebar-transparent .ti
 
 /* Style Context - mobile toolbar transparency (opt-in) */
 
-body.sc-style-context-background-image.sc-style-context-mobile-toolbar-transparent .mobile-toolbar-spacer {
+body.sc-style-context-background-image.sc-style-context-background-image.sc-style-context-mobile-toolbar-transparent .mobile-toolbar-spacer {
 	background-color: transparent;
 	background-image: none;
 }
 
-body.sc-style-context-background-image.sc-style-context-mobile-toolbar-transparent.is-floating-nav .mobile-toolbar,
-body.sc-style-context-background-image.sc-style-context-mobile-toolbar-transparent .is-floating-nav .mobile-toolbar {
+body.sc-style-context-background-image.sc-style-context-background-image.sc-style-context-mobile-toolbar-transparent.is-floating-nav .mobile-toolbar,
+body.sc-style-context-background-image.sc-style-context-background-image.sc-style-context-mobile-toolbar-transparent .is-floating-nav .mobile-toolbar {
 	box-shadow: none;
 }
 
 /* Style Context - status bar transparency (opt-out) */
 
-body.sc-style-context-background-image.sc-style-context-status-bar-transparent .status-bar {
+body.sc-style-context-background-image.sc-style-context-background-image.sc-style-context-status-bar-transparent .status-bar {
 	background-color: transparent;
 	background-image: none;
 }
@@ -354,7 +381,8 @@ body.sc-style-context-background-image.sc-style-context-status-bar-transparent .
 
 .sc-background-image-preview.is-valid {
 	background-color: var(--background-primary);
-	background-image: none;
+	/* Mirror the canvas repaint so gradient themes preview their gradient. */
+	background-image: var(--sc-style-context-theme-canvas);
 }
 
 .sc-background-image-preview.is-valid::before {
@@ -363,8 +391,8 @@ body.sc-style-context-background-image.sc-style-context-status-bar-transparent .
 	inset: var(--sc-background-image-preview-inset);
 	pointer-events: none;
 	background-color: var(--background-primary);
-	background-image: var(--sc-background-image-preview-value);
-	background-blend-mode: var(--sc-background-image-preview-blend-mode);
+	background-image: var(--sc-background-image-preview-value), var(--sc-style-context-theme-canvas);
+	background-blend-mode: var(--sc-background-image-preview-blend-mode), normal;
 	background-size: var(--sc-background-image-preview-size);
 	background-position: var(--sc-background-image-preview-position);
 	background-repeat: var(--sc-background-image-preview-repeat);


### PR DESCRIPTION
## Problem

The background image feature's transparency handling only accounted for the solid `--background-primary` canvas. Composer declares its canvas with a theme-specific gradient token and paints it on the workspace:

```css
body:not(.is-phone) .workspace { background: var(--background-gradient); }
```

That rule ties with the plugin's transparency resets at specificity (0,2,1), and since Obsidian appends `theme.css` **after** plugin stylesheets, the theme won every tie — the gradient covered the background image entirely.

## Solution

Introduces a dedicated **theme compatibility layer** at the top of `styles.css` with exactly two extension points, so supporting a new theme touches these and nothing else:

1. **Canvas token chain** — `--sc-style-context-theme-canvas: var(--background-gradient, none)` resolves how a theme *expresses* its canvas. It is painted on the repainted body and layered beneath the image (with blend mode `normal` for that layer), so blend and cross-fade stay anchored to the theme's real canvas instead of flattening it to `--background-primary`. Themes without the token resolve to `none` — zero behavior change. The settings preview mirrors the same treatment.
2. **Surface resets** — every transparency reset now repeats the marker class once (specificity (0,3,1)), so equal-specificity theme rules cannot win regardless of stylesheet order. `!important` remains banned by the stylelint config.

Verified against Composer's published stylesheet: no `!important`, and its strongest background rules are (0,2,1) — now outranked. README documents the SOP (EN + CN) and CHANGELOG carries an `## [Unreleased]` entry per the release flow.

## Verification

- `npm run lint` ✅
- `npm test` — 87 passed ✅
- `npm run build` ✅

<details>
<summary>中文说明（点击展开）</summary>

### 问题

背景图的透明化处理只考虑了 `--background-primary` 纯色画布。Composer 用自有 token 在 `.workspace` 上绘制渐变画布，该规则与插件的透明化规则同特异性 (0,2,1)，而 Obsidian 中 theme.css 在插件 CSS 之后加载，同特异性下主题恒胜——渐变完全盖住了背景图。

### 方案

在 `styles.css` 顶部引入主题兼容层，有且只有两个扩展点：

1. **画布 token 链**（`--sc-style-context-theme-canvas`）：统一解析主题如何表达画布；绘制在重绘的 body 上并垫在图片下方（该层混合模式固定 `normal`），使混合与交叉渐变锚定主题真实画布。无此 token 的主题解析为 `none`，行为零变化。设置页预览同步。
2. **表面重置**：所有透明化规则重复标记 class（特异性 (0,3,1)），无论加载顺序都不再输给同特异性主题规则；`!important` 仍被 stylelint 禁用。

兼容新主题 = 把画布 token 追加进链，仅当主题在额外表面绘制不透明背景时才向重置列表加选择器。README（中英）记录了该 SOP，CHANGELOG 按发布流程写入 `## [Unreleased]`。

</details>